### PR TITLE
Adding PersistentServices script

### DIFF
--- a/Scripts/Services/PersistentServices.cs
+++ b/Scripts/Services/PersistentServices.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Fjord.Common.Services
+{
+    public class PersistentServices : MonoBehaviour
+    {
+        [SerializeField]
+        private bool _instantiateBeforeSceneLoad = true;
+
+        static private PersistentServices _instance;
+
+        static public PersistentServices Instance
+        {
+            get
+            {
+                if (null == _instance)
+                {
+                    _instance = FindObjectOfType<PersistentServices>();
+                }
+                return _instance;
+            }
+        }
+
+        public bool InstantiateBeforeSceneLoad { get { return _instantiateBeforeSceneLoad; } }
+
+        static public T GetService<T>()
+        {
+            return Instance.GetComponentInChildren<T>();
+        }
+
+        static public T[] GetServices<T>()
+        {
+            return Instance.GetComponentsInChildren<T>();
+        }
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        static private void Init()
+        {
+            if (null == _instance)
+            {
+                PersistentServices prefab = Resources.Load<PersistentServices>("PersistentServices");
+                if (null != prefab && prefab.InstantiateBeforeSceneLoad)
+                {
+                    DontDestroyOnLoad(Instantiate(prefab));
+                    Debug.Log("Instantiated Persistent Services.");
+                }
+                else
+                {
+                    Debug.LogWarning("Persistent Services already instantiated.");
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Services/PersistentServices.cs.meta
+++ b/Scripts/Services/PersistentServices.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e62f911873fc5a94fa7bee4ef0a64c7d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adding PersistentServices script which creates a singleton prefab immediately upon scene load. Child service objects can be added to the prefab for global access.