### PR TITLE
Fix for UnregisterListener in EventDispatcher

### DIFF
--- a/Scripts/Events/EventDispatcher.cs
+++ b/Scripts/Events/EventDispatcher.cs
@@ -33,10 +33,6 @@ namespace Fjord.Common.Events
             if (eventMap.ContainsKey(eventName))
             {
                 eventMap[eventName].RemoveListener(callback);
-                if(eventMap[eventName].GetPersistentEventCount() == 0)
-                {
-                    eventMap.Remove(eventName);
-                }
             }
         }
         public void Dispatch(string eventName, object sender, object eventArg)

--- a/Scripts/Events/EventDispatcher.cs
+++ b/Scripts/Events/EventDispatcher.cs
@@ -18,11 +18,6 @@ namespace Fjord.Common.Events
         [SerializeField]
         private Dictionary<string, StandardEvent> eventMap = new Dictionary<string, StandardEvent>();
 
-        protected override void Awake()
-        {
-            _dontDestroyOnLoad = true;
-            base.Awake();
-        }
 
         public void RegisterListener(string eventName, UnityAction<object, object> callback)
         {

--- a/Scripts/Events/EventDispatcher.cs
+++ b/Scripts/Events/EventDispatcher.cs
@@ -18,6 +18,12 @@ namespace Fjord.Common.Events
         [SerializeField]
         private Dictionary<string, StandardEvent> eventMap = new Dictionary<string, StandardEvent>();
 
+        protected override void Awake()
+        {
+            _dontDestroyOnLoad = true;
+            base.Awake();
+        }
+
         public void RegisterListener(string eventName, UnityAction<object, object> callback)
         {
             if (!eventMap.ContainsKey(eventName))


### PR DESCRIPTION
PersistentListenerCount is only incremented through event set in the inspector, NOT event set through scripting. This count was almost always 0 which cause Events to be removed if a single entity called UnregisterListener.